### PR TITLE
Fix gazebo errors

### DIFF
--- a/flir_ptu_description/urdf/d46.urdf.xacro
+++ b/flir_ptu_description/urdf/d46.urdf.xacro
@@ -64,9 +64,20 @@
   <xacro:macro name="ptu_d46" params="name">
     <d46_stepper_module ptu_name="${name}" joint_name="pan" />
     <d46_stepper_module ptu_name="${name}" joint_name="tilt" />
-    <link name="${name}_base_link" />
-    <link name="${name}_tilted_link" />
-    <link name="${name}_mount_link" />
+    <link name="${name}_base_link">
+<inertial>
+			<mass value="2e-06"/>
+			<inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
+		</inertial>
+    </link>
+    <link name="${name}_tilted_link"/>
+      
+    <link name="${name}_mount_link">
+<inertial>
+			<mass value="2e-06"/>
+			<inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
+		</inertial>
+    </link>
 
     <!-- There's an offset between the origin of the pan joint and the origin of 
          the overall device, which is between the mounting screws on its base. -->


### PR DESCRIPTION
Without these inertial links, these links are not created as gazebo only creates links with inertial elements. Therefore, I cannot initialize transmissions for the joints that join these links because a transmission requires that the joint has both of its child and parent links to be existent for hardware interface to work.
