### PR TITLE
Driver was crashing. Change nulls and emptys to 0s to allow typecasti…

### DIFF
--- a/flir_ptu_driver/src/driver.cpp
+++ b/flir_ptu_driver/src/driver.cpp
@@ -51,6 +51,12 @@ T parseResponse(std::string responseBuffer)
 {
   std::string trimmed = responseBuffer.substr(1);
   boost::trim(trimmed);
+
+  if (trimmed.empty())
+  {
+      trimmed = "0";
+  }
+
   T parsed = lexical_cast<T>(trimmed);
   ROS_DEBUG_STREAM("Parsed response value: " << parsed);
   return parsed;


### PR DESCRIPTION
Driver was crashing on a real PTU. This happened because the very first request made to the PTU after powering on (not initialize sequence) was returning a null/empty character. 

To prevent this crashing and to make sure the user doesn't have to launch twice, this will turn any emptys/nulls to "0" so that typecasting works.

