### PR TITLE
Fix missing xacro namespace prefixes

### DIFF
--- a/flir_ptu_description/urdf/d46.urdf.xacro
+++ b/flir_ptu_description/urdf/d46.urdf.xacro
@@ -112,7 +112,7 @@
              effort="${joint_effort}" velocity="${pan_velocity}" />
     </joint>
 
-    <d46_transmission name="${name}_pan" />
+    <xacro:d46_transmission name="${name}_pan" />
 
     <!-- The tilt joint -->
     <joint name="${name}_tilt" type="revolute">
@@ -124,7 +124,7 @@
              effort="${joint_effort}" velocity="${tilt_velocity}" />
     </joint>
 
-    <d46_transmission name="${name}_tilt" />
+    <xacro:d46_transmission name="${name}_tilt" />
 
     <!-- Fixed joint to provide a convenient attachment point for accessories. -->
     <joint name="${name}_mount" type="fixed">

--- a/flir_ptu_description/urdf/example.urdf.xacro
+++ b/flir_ptu_description/urdf/example.urdf.xacro
@@ -5,7 +5,7 @@
 
   <!-- Include and invoke the macro which creates a D46 -->
   <xacro:include filename="d46.urdf.xacro" />
-  <ptu_d46 name="ptu" />
+  <xacro:ptu_d46 name="ptu" />
 
   <!-- Create a fixed joint to connect the PTU to the rest of the robot -->
   <joint name="base_to_ptu_base" type="fixed">


### PR DESCRIPTION
In Noetic `xacro` will require `xacro` namespace prefixes for all `xacro` tags, but also for all macros. This PR fixes the macros.