### PR TITLE
Add stand_alone arg to turn off robot_state_publisher

### DIFF
--- a/flir_ptu_driver/launch/ptu.launch
+++ b/flir_ptu_driver/launch/ptu.launch
@@ -1,12 +1,15 @@
 <launch>
-  <arg name="port" default="/dev/ptu" /> <!-- Suggest using Udev rules to make a consistent serial port -->
-  <arg name="limits_enabled" default="false" /> <!-- Disable software range limits by setting to false -->
+  <arg name="port"           default="/dev/ptu" /> <!-- Suggest using Udev rules to make a consistent serial port -->
+  <arg name="limits_enabled" default="false" />    <!-- Disable software range limits by setting to false -->
+  <arg name="stand_alone"    default="false" />    <!-- Set to true to load description & start state publisher -->
 
   <!-- When you integrate into your platform, use the provided xacro macro to include
        the D46 URDF with your larger platform description, and have your platform's
        joint_state_publisher subscribe to the ptu state. -->
-  <param name="robot_description" textfile="$(find flir_ptu_description)/urdf/example.urdf" /> 
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <group if="$(arg stand_alone)">
+    <param name="robot_description" textfile="$(find flir_ptu_description)/urdf/example.urdf" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  </group>
 
   <node name="ptu_driver" pkg="flir_ptu_driver" type="ptu_node" ns="ptu" respawn="true">
     <param name="port" value="$(arg port)" />


### PR DESCRIPTION
Don't load the description & start the robot_state_publisher by default; this breaks things when we mount the PTU on another robot.