### PR TITLE
Add Gazebo Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,98 @@ flir_ptu
 
 Basic serial ROS driver for FLIR PTUs. Currently tested with:
 
- - [FLIR D46](http://www.flir.com/mcs/view/?id=53707)
+ - [FLIR D46](http://www.flir.com/mcs/view/?id=53707) using tty
+ - [FLIR E46](https://www.flir.com/products/ptu-e46/) using either tty or tcp
  - [FLIR D48E](http://www.flir.com/mcs/view/?id=53670) using either tty or tcp
 
 
+Usage
+------
+
+This repository contains the description and driver ROS packages for using the Flir D46 and E46 pan-tilt units.
+Refer to Flir's documentation for physically connecting the unit to your robot.
+
+The driver supports both TTY and TCP connections between the robot's PC and the PTU.
+
+Add the `ptu_d46` macro to your URDF, making sure to add a joint between the mounting location and `${name}_base_link`:
+```xml
+<xacro:include filename="$(find flir_ptu_description)/urdf/d46.urdf.xacro" />
+<xacro:ptu_d46 name="ptu" />
+<joint name="ptu_base_joint" type="fixed">
+  <parent link="base_link" />
+  <child link="ptu_base_link" />
+  <origin xyz="0.24 0.0 -0.13" rpy="0 0 0" />
+</joint>
+```
+
+To start the driver in TTY mode, run
+```bash
+roslaunch flir_ptu_driver connection_type:=tty port:=/dev/ttyS0
+```
+
+To start the driver in TCP mode, run
+```bash
+roslaunch flir_ptu_driver connection_type:=tcp ip_addr:=192.168.131.70 tcp_port:=4000
+```
+
+
+Topics
+-------
+
+Publications:
+- `state` (normally remapped to `/joint_states`): `sensor_msgs/JointState` -- the current state of the pan and tilt
+  actuators.
+
+Subscriptions:
+- `cmd`: `sensor_msgs/JointState` -- command the PTU to move to the desired angle with the requested speed
+- `reset`: `std_msgs/Bool` -- publish `true` to reset the PTU, publish `false` to stop the reset
+
+When publishing to the `cmd` topic, the `name`, `position`, and `velocity` arrays must be of length 2, with the
+pan actuator first and the tilt actuator second.  The `effort` field is ignored.
+
+```bash
+rostopic pub /ptu/cmd sensor_msgs/JointState "header:
+  seq: 0
+  stamp: {secs: 0, nsecs: 0}
+  frame_id: ''
+name: ['ptu_pan', 'ptu_tilt']
+position: [$(deg2rad 135), $(deg2rad -20)]
+velocity: [0]
+effort: [0]" -1
+```
+
+Positive pan angles will rotate the unit to the left and negative angles will rotate it to the right.
+
+Positive tilt angles will rotate the unit upward and negative angles will rotate it downward.
+
+
+Simulation
+-----------
+
+The `flir_ptu_driver` package also contains a script and launch file designed to allow the PTU to be simulated using
+Gazebo.  The simulation is not a perfect 1:1 replication of the behaviour of the physical PTU, but it does allow the
+simulated PTU to be controlled using the same ROS topics as the real product.
+
+To start the simulation driver, run
+```bash
+roslaunch flir_ptu_driver ptu_simulation.launch name:=ptu
+```
+
+Make sure the `name` argument matches the `name` attribute of the `<xacro:ptu_d46>` tag in the robot's URDF.
+
+Under the hood, the simulation driver uses two `velocity_controllers/JointPositionController` controllers, one each
+to control the pan and tilt actuators.  The PID gains for these controllers can be found in
+`flir_ptu_driver/launch/ptu_simulation.launch`.
+
+In simulation mode, the `velocity` field of the `cmd` topic is ignored; the speed of the joints' rotation is
+governed wholly by the PID controllers implemented bu the `JointPositionController`s.
+
+In simulation mode, the driver does not publish to `state`; instead the `JointPositionController`s publish directly
+to `/joint_states` via the `/gazebo` ROS node.
+
+
 License
-=======
+--------
 
 This repo originated at [Washington University](https://wu-robotics.googlecode.com/svn/branches/stable/wu_ptu),
 where the code was licensed as GPLv2. The initial copy was made at svn revision r2226.

--- a/flir_ptu_description/urdf/d46.urdf.xacro
+++ b/flir_ptu_description/urdf/d46.urdf.xacro
@@ -11,10 +11,10 @@
     <transmission name="${name}_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${name}">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${name}_motor">
-        <mechanicalReduction>1</mechanicalReduction>
+          <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
   </xacro:macro>

--- a/flir_ptu_driver/launch/ptu_simulation.launch
+++ b/flir_ptu_driver/launch/ptu_simulation.launch
@@ -1,8 +1,8 @@
 <launch>
   <arg name="name"           default="ptu" />
 
-  <group ns="$(arg name)">
-    <rosparam subst_value="true">
+  <rosparam subst_value="true">
+    $(arg name):
       $(arg name)_pan_position_controller:
         type: "velocity_controllers/JointPositionController"
         joint: "$(arg name)_pan"
@@ -18,10 +18,11 @@
           p: 1.0
           i: 0.01
           d: 0.1
-    </rosparam>
-    <node name="$(anon ptu_controller_spawner)" pkg="controller_manager" type="spawner"
-          args="$(arg name)_pan_position_controller $(arg name)_tilt_position_controller"/>
+  </rosparam>
+  <node name="$(anon ptu_controller_spawner)" pkg="controller_manager" type="spawner"
+        args="$(arg name)/$(arg name)_pan_position_controller $(arg name)/$(arg name)_tilt_position_controller"/>
 
+  <group ns="$(arg name)">
     <node name="$(arg name)_ptusim_driver" pkg="flir_ptu_driver" type="ptu_simulation_node" output="screen">
       <param name="name"  value="$(arg name)" />
       <remap from="state" to="/joint_states" />

--- a/flir_ptu_driver/launch/ptu_simulation.launch
+++ b/flir_ptu_driver/launch/ptu_simulation.launch
@@ -1,0 +1,30 @@
+<launch>
+  <arg name="name"           default="ptu" />
+
+  <group ns="$(arg name)">
+    <rosparam subst_value="true">
+      $(arg name)_pan_position_controller:
+        type: "velocity_controllers/JointPositionController"
+        joint: "$(arg name)_pan"
+        pid:
+          p: 1.0
+          i: 0.01
+          d: 0.1
+
+      $(arg name)_tilt_position_controller:
+        type: "velocity_controllers/JointPositionController"
+        joint: "$(arg name)_tilt"
+        pid:
+          p: 1.0
+          i: 0.01
+          d: 0.1
+    </rosparam>
+    <node name="$(anon ptu_controller_spawner)" pkg="controller_manager" type="spawner"
+          args="$(arg name)_pan_position_controller $(arg name)_tilt_position_controller"/>
+
+    <node name="$(arg name)_ptusim_driver" pkg="flir_ptu_driver" type="ptu_simulation_node" output="screen">
+      <param name="name"  value="$(arg name)" />
+      <remap from="state" to="/joint_states" />
+    </node>
+  </group>
+</launch>

--- a/flir_ptu_driver/package.xml
+++ b/flir_ptu_driver/package.xml
@@ -5,13 +5,13 @@
   <description>Driver for the FLIR pan/tilt units.</description>
 
   <maintainer email="mpurvis@clearpathrobotics.com">Mike Purvis</maintainer>
-  
+
   <url type="website">http://wiki.ros.org/flir_ptu_driver</url>
   <url type="repository">https://github.com/ros-drivers/flir_ptu.git</url>
   <url type="bugtracker">https://github.com/ros-drivers/flir_ptu/issues</url>
 
   <!-- Authors -->
-  <author email="erik@cse.wustl.edu">Erik Karulf</author> 
+  <author email="erik@cse.wustl.edu">Erik Karulf</author>
   <author email="davidlu@wustl.edu">David V. Lu</author>
   <author email="n.a.hawes@cs.bham.ac.uk">Nick Hawes</author>
 
@@ -36,6 +36,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>serial</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
 
 </package>

--- a/flir_ptu_driver/package.xml
+++ b/flir_ptu_driver/package.xml
@@ -29,6 +29,7 @@
   <build_depend>serial</build_depend>
   <build_depend>tf</build_depend>
   <run_depend>actionlib</run_depend>
+  <run_depend>controller_manager</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>flir_ptu_description</run_depend>
   <run_depend>robot_state_publisher</run_depend>
@@ -38,5 +39,6 @@
   <run_depend>serial</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>velocity_controllers</run_depend>
 
 </package>

--- a/flir_ptu_driver/scripts/ptu_simulation_node
+++ b/flir_ptu_driver/scripts/ptu_simulation_node
@@ -74,7 +74,7 @@ class PtuSimulationNode:
             rospy.logwarn(f'Requested pan of {pan} is too small. Clipping to {self.MIN_PAN}')
             pan = self.MIN_PAN
         elif pan > self.MAX_PAN:
-            rospy.logwarn(f'Requested pan of {pan} is too large. Clipping to {self.MAZ_PAN}')
+            rospy.logwarn(f'Requested pan of {pan} is too large. Clipping to {self.MAX_PAN}')
             pan = self.MAX_PAN
 
         if tilt < self.MIN_TILT:

--- a/flir_ptu_driver/scripts/ptu_simulation_node
+++ b/flir_ptu_driver/scripts/ptu_simulation_node
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+A node that communicates directly with the velocity_controllers/JointPositionController controllers
+provided by d46.urdf.xacro to control the position of the pan and tilt actuators.
+
+This provides a loose approximation of the Flir PTU driver, but with some limitations:
+- the position is controlled through a PID controller, so some oscillation may occur
+- the velocity of the rotation is not affected by the velocity sent to the cmd topic
+
+Externally this node should behave with the same set of ROS topics and services you would expect
+to see on the ptu_node running on real hardware:
+
+Publications:
+- ${name}_pan_position_controller/command (std_msgs/Float64) -- used to command the underlying PID controller
+- ${name}_tilt_position_controller/command (std_msgs/Float64) -- see above
+
+Normally the ptu_node publishes to /state, but this is normally remapped to /joint_states.  In this
+case the underlying JointPositionController instances publish to /joint_states for us, so there's no
+additional work needed for this node
+
+Subscriptions:
+- cmd (sensor_msgs/JointState) -- the desired pan and tilt position for the unit
+- reset (std_msgs/Bool) -- reset the unit to its default position (0, 0)
+"""
+
+import rospy
+
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Bool, Float64
+
+## The simulation node itself
+#
+#  This class provides the same external ROS interfaces as the flir_ptu_driver/ptu_node, but instead of
+#  interacting with the underlying hardware it instead interacts with two velocity_controllers/JointPositionController
+#  controllers to move the pan and tilt servos
+#
+#  See flir_ptu_description/urdf/d46.urdf.xacro for angle limits reproduced below
+class PtuSimulationNode:
+    ## Minumum reachable pan angle (rad)
+    MIN_PAN = -2.775
+
+    ## Maximum reachable pan angle (rad)
+    MAX_PAN = 2.775
+
+    ## Minimum reachable tilt angle (rad)
+    MIN_TILT = -0.82
+
+    ## Maximum reachable tilt angle (rad)
+    MAX_TILT = 0.52
+
+    def __init__(self):
+        self.name = rospy.get_param('~name', 'ptu')
+
+    ## Connect the publishers and subscribers
+    def start(self):
+        self.cmd_sub = rospy.Subscriber('cmd', JointState, self.cmd_callback)
+        self.reset_sub = rospy.Subscriber('reset', Bool, self.reset_callback)
+
+        self.pan_cmd = rospy.Publisher(f'{self.name}_pan_position_controller/command', Float64, queue_size=1)
+        self.tilt_cmd = rospy.Publisher(f'{self.name}_tilt_position_controller/command', Float64, queue_size=1)
+
+    ## Move the PTU to the desired position, respecting the limits
+    #
+    #  \param  desired_state  The desired pan/tilt position. Index 0 is the pan angle, index 1 is the tilt angle
+    def cmd_callback(self, desired_state):
+        if len(desired_state.position) != 2:
+            rospy.logwarn(f'Wrong number of positions: {len(desired_state.position)}. Expected 2. Dropping request')
+            return
+
+        pan = desired_state.position[0]
+        tilt = desired_state.position[1]
+
+        if pan < self.MIN_PAN:
+            rospy.logwarn(f'Requested pan of {pan} is too small. Clipping to {self.MIN_PAN}')
+            pan = self.MIN_PAN
+        elif pan > self.MAX_PAN:
+            rospy.logwarn(f'Requested pan of {pan} is too large. Clipping to {self.MAZ_PAN}')
+            pan = self.MAX_PAN
+
+        if tilt < self.MIN_PAN:
+            rospy.logwarn(f'Requested tilt of {tilt} is too small. Clipping to {self.MIN_TILT}')
+            tilt = self.MIN_TILT
+        elif pan > self.MAX_TILT:
+            rospy.logwarn(f'Requested tilt of {tilt} is too large. Clipping to {self.MAX_TILT}')
+            tilt = self.MAX_TILT
+
+        self.pan_cmd.publish(Float64(pan))
+        self.tilt_cmd.publish(Float64(tilt))
+
+
+    def reset_callback(self, cmd):
+        if cmd.data:
+            self.pan_cmd.publish(Float64(0.0))
+            self.tilt_cmd.publish(Float64(0.0))
+
+## Create the node and run it
+def main():
+    rospy.init_node('ptu_simulation_node', anonymous=True)
+    node = PtuSimulationNode()
+    node.start()
+    rospy.spin()
+
+if __name__=='__main__':
+    main()

--- a/flir_ptu_driver/scripts/ptu_simulation_node
+++ b/flir_ptu_driver/scripts/ptu_simulation_node
@@ -77,10 +77,10 @@ class PtuSimulationNode:
             rospy.logwarn(f'Requested pan of {pan} is too large. Clipping to {self.MAZ_PAN}')
             pan = self.MAX_PAN
 
-        if tilt < self.MIN_PAN:
+        if tilt < self.MIN_TILT:
             rospy.logwarn(f'Requested tilt of {tilt} is too small. Clipping to {self.MIN_TILT}')
             tilt = self.MIN_TILT
-        elif pan > self.MAX_TILT:
+        elif tilt > self.MAX_TILT:
             rospy.logwarn(f'Requested tilt of {tilt} is too large. Clipping to {self.MAX_TILT}')
             tilt = self.MAX_TILT
 

--- a/flir_ptu_driver/src/node.cpp
+++ b/flir_ptu_driver/src/node.cpp
@@ -285,7 +285,7 @@ void Node::testPanTilt(void)
      count = static_cast<int>(radian / m_pantilt->getResolution(pt));
      ROS_INFO_STREAM("NODE::testPanTilt] PTU set tilt " << pt << count);
   }
-} 
+}
 
 
 /**
@@ -296,29 +296,23 @@ void Node::spinCallback(const ros::TimerEvent&)
 {
   if (!ok()) return;
 
-  // Read Position & Speed
+  // Read Position
   double pan  = m_pantilt->getPosition(PTU_PAN);
   double tilt = m_pantilt->getPosition(PTU_TILT);
 
-  double panspeed  = m_pantilt->getSpeed(PTU_PAN);
-  double tiltspeed = m_pantilt->getSpeed(PTU_TILT);
-
-  // Publish Position & Speed
+  // Publish Position
   sensor_msgs::JointState joint_state;
   joint_state.header.stamp = ros::Time::now();
   joint_state.name.resize(2);
   joint_state.position.resize(2);
-  joint_state.velocity.resize(2);
   joint_state.name[0] = m_joint_name_prefix + "pan";
   joint_state.position[0] = pan;
-  joint_state.velocity[0] = panspeed;
   joint_state.name[1] = m_joint_name_prefix + "tilt";
   joint_state.position[1] = tilt;
-  joint_state.velocity[1] = tiltspeed;
   m_joint_pub.publish(joint_state);
 
   m_updater->update();
-  
+
   if(m_test_mode)testPanTilt();
 }
 

--- a/flir_ptu_viz/CMakeLists.txt
+++ b/flir_ptu_viz/CMakeLists.txt
@@ -4,10 +4,5 @@ project(flir_ptu_viz)
 find_package(catkin REQUIRED COMPONENTS roslaunch)
 catkin_package()
 
-roslaunch_add_file_check(launch/view_model.launch
-  DEPENDENCIES flir_ptu_example_urdf robot_state_publisher)
-roslaunch_add_file_check(launch/view_ptu.launch
-  DEPENDENCIES rviz)
-
 install(DIRECTORY launch rviz
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/flir_ptu_viz/CMakeLists.txt
+++ b/flir_ptu_viz/CMakeLists.txt
@@ -4,5 +4,8 @@ project(flir_ptu_viz)
 find_package(catkin REQUIRED COMPONENTS roslaunch)
 catkin_package()
 
+roslaunch_add_file_check(launch/view_model.launch)
+roslaunch_add_file_check(launch/view_ptu.launch)
+
 install(DIRECTORY launch rviz
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/flir_ptu_viz/launch/view_model.launch
+++ b/flir_ptu_viz/launch/view_model.launch
@@ -1,7 +1,9 @@
 <launch>
-	<param name="robot_description" textfile="$(find flir_ptu_description)/urdf/example.urdf" />
-	<param name="use_gui" value="True"/>
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
-	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find flir_ptu_viz)/rviz/urdf.rviz" required="true" />
+  <param name="robot_description" textfile="$(find flir_ptu_description)/urdf/example.urdf" />
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" />
+
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find flir_ptu_viz)/rviz/urdf.rviz" required="true" />
+
 </launch>

--- a/flir_ptu_viz/package.xml
+++ b/flir_ptu_viz/package.xml
@@ -13,6 +13,7 @@
   <build_depend>roslaunch</build_depend>
   <run_depend>flir_ptu_description</run_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rviz</run_depend>
 


### PR DESCRIPTION
Add support for controlling the PTU inside of a Gazebo simulation.

The behaviour of the simulation isn't 100% identical, but the main ROS interfaces (`/joint_states` and `/ptu/cmd`) are replicated.  A pair of `velocity_controllers/JointPositionController`s are used to control the pan and tilt actuators, with a simple Python node acting as a middle layer between the PID controllers' `.../command` topics and the Flir PTU's `.../cmd` topic.

The biggest difference between the simulation and the real thing is that in the simulation the velocity of the rotation cannot be controlled; the speed of rotation is governed wholly by the PID controllers implemented by the `JointPositionController` instances.  But the angles can be set using the same ROS interface, and the PTU does move, which is the most important aspect.